### PR TITLE
Improve build flexibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     id("org.jetbrains.kotlin.jvm")
 }
 
+val libs = project.extensions.getByType<org.gradle.accessors.dm.LibrariesForLibs>()
+
 apply(plugin = "compiler.gradleplugin.plantumlgenerator")
 
 
@@ -21,9 +23,9 @@ repositories {
 
 dependencies {
     testImplementation(kotlin("test"))
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.2")
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testImplementation(libs.junit.jupiter.params)
 }
 
 tasks.test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,28 @@
+import org.gradle.api.publish.PublishingExtension
+
+val javaVersion = providers.gradleProperty("javaVersion").orNull?.toInt() ?: 17
+
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(javaVersion))
     }
+}
+
+subprojects {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(javaVersion.toString()))
+    }
+
+    plugins.withId("maven-publish") {
+        extensions.configure<PublishingExtension> {
+            repositories { mavenLocal() }
+        }
+    }
+}
+
+tasks.register("publishAllToMavenLocal") {
+    dependsOn(gradle.includedBuild("compiler-plugin").task("publishToMavenLocal"))
+    dependsOn(gradle.includedBuild("gradle-plugin").task("publishToMavenLocal"))
 }
 
 buildscript {

--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -13,6 +13,8 @@ plugins {
 
 }
 
+val libs = project.extensions.getByType<org.gradle.accessors.dm.LibrariesForLibs>()
+
 allprojects {
     repositories {
         mavenLocal()
@@ -26,13 +28,11 @@ allprojects {
 
 group = "dev.benelli"
 version = "0.0.1"
-val autoService = "1.1.1"
-val autoServiceKsp = "1.2.0"
 dependencies {
-    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.1.0")
-    ksp("dev.zacsweers.autoservice:auto-service-ksp:$autoServiceKsp")
-    implementation("com.google.auto.service:auto-service-annotations:$autoService")
-    
+    compileOnly(libs.kotlin.compiler.embeddable)
+    ksp(libs.auto.service.ksp)
+    implementation(libs.auto.service)
+
 }
 
 publishing {
@@ -87,13 +87,15 @@ publishing {
     }
 }
 
+val javaVersion = providers.gradleProperty("javaVersion").orNull?.toInt() ?: 17
+
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(javaVersion)
 }
 
 
 tasks.withType<KotlinCompile> {
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_17)
+    compilerOptions.jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
 }
 tasks.withType<KotlinCompilationTask<*>>().configureEach {
     compilerOptions.freeCompilerArgs.add("-opt-in=org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi")

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -4,6 +4,20 @@ plugins {
     `maven-publish`
 }
 
+val libs = project.extensions.getByType<org.gradle.accessors.dm.LibrariesForLibs>()
+
+val javaVersion = providers.gradleProperty("javaVersion").orNull?.toInt() ?: 17
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(javaVersion))
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(javaVersion.toString()))
+}
+
 group = "dev.benelli"
 version = "1.0.0"
 
@@ -18,7 +32,7 @@ allprojects {
     }
 }
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:2.1.20")
+    implementation(libs.kotlin.gradle.plugin.api)
 }
 
 gradlePlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ kotlin.compiler.execution.strategy=in-process
 kotlin.daemon.debug.log=true
 org.gradle.jvmargs=-Xmx2g
 version=0.0.1
+javaVersion=17

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,12 @@ kotlin = "2.1.20"
 
 [libraries]
 kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version = "5.10.2" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version = "5.10.2" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version = "5.10.2" }
+auto-service = { module = "com.google.auto.service:auto-service-annotations", version = "1.1.1" }
+auto-service-ksp = { module = "dev.zacsweers.autoservice:auto-service-ksp", version = "1.2.0" }
+kotlin-gradle-plugin-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin"}


### PR DESCRIPTION
## Summary
- make Java version configurable via `javaVersion` property
- default to local Maven publishing for modules with `maven-publish`
- centralize dependency versions in `libs.versions.toml`
- use version catalog entries in module build scripts
- provide a helper task for publishing all artifacts locally

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68431b0f8244833199b80aab66e1955d