### PR TITLE
Implement aggregated publishToMavenLocal

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,8 @@
 
 ## Usage
 
-* Inside the project folder run `./gradlew clean build` 
+* Inside the project folder run `./gradlew clean build`
+* Publish the compiler and Gradle plugin to your local Maven repository with `./gradlew publishToMavenLocal`
 
 The plugin is only active when the build cache is changed. This is why you need to run "clean" before building, when you want to see the log output again.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,3 +40,10 @@ allprojects {
     }
 }
 
+tasks.register("publishToMavenLocal") {
+    dependsOn(
+        gradle.includedBuild("compiler-plugin").task(":publishToMavenLocal"),
+        gradle.includedBuild("gradle-plugin").task(":publishToMavenLocal")
+    )
+}
+


### PR DESCRIPTION
## Summary
- add root task to publish compiler and gradle plugins to Maven local
- document how to publish to Maven local

## Testing
- `./gradlew clean build`
- `./gradlew publishToMavenLocal`


------
https://chatgpt.com/codex/tasks/task_e_684f2955b318833196b73b07af58e650